### PR TITLE
`replace` parameter of `save_workspace()` corrected in R (not in Java)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Correction of imports when the workspace contains no SAP.
 
+* `replace` parameter of `save_workspace()` corrected in R (not in Java).
+
 ## [3.2.3] - 2024-07-12
 
 

--- a/R/workspace.R
+++ b/R/workspace.R
@@ -263,7 +263,14 @@ read_workspace <- function(jws, compute = TRUE) {
 save_workspace <- function(jws, file, replace = FALSE) {
     # version <- match.arg(tolower(version)[1], c("jd3", "jd2"))
     version <- "jd3"
-    invisible(.jcall(jws, "Z", "saveAs", full_path(file), version, !replace))
+    file <- full_path(file)
+    if (replace && file.exists(file)) {
+        base::file.remove(file)
+        base::unlink(
+            gsub("\\.xml$", "", file),
+            recursive = TRUE)
+    }
+    invisible(.jcall(jws, "Z", "saveAs", file, version, !replace))
 }
 
 full_path <- function(path) {


### PR DESCRIPTION
`replace` parameter of `save_workspace()` corrected in R (not in Java) to solve #1 